### PR TITLE
fix(inspect): support -f flag and {{.State.Running}} format

### DIFF
--- a/src/container_docker_shim/cli.py
+++ b/src/container_docker_shim/cli.py
@@ -560,7 +560,7 @@ def cmd_inspect(argv: list[str]) -> int:
     i = 0
     while i < len(argv):
         arg, value = _split_long(argv[i])
-        if arg == "--format":
+        if arg in ("-f", "--format"):
             fmt = value
             if fmt is None:
                 fmt, i = _take_value(argv, i, arg)
@@ -596,6 +596,10 @@ def cmd_inspect(argv: list[str]) -> int:
                     print(DOCKER_ZERO_TIME)
                 else:
                     print(row.get("finished_at") or DOCKER_ZERO_TIME)
+            return 0
+        if fmt == "{{.State.Running}}":
+            for row in rows:
+                print("true" if row.get("state") == "running" else "false")
             return 0
         return _die(f"unsupported inspect format: {fmt}", 64)
 


### PR DESCRIPTION
## Summary

Fixes two Docker CLI compatibility gaps in `docker inspect`:

1. **Accept `-f` as alias for `--format`** — Docker supports both, but the shim only accepted `--format`
2. **Support `{{.State.Running}}` Go template** — returns `true`/`false` based on container state

## Motivation

OpenClaw (and likely other Docker-dependent tools) uses these patterns to check sandbox container state:

```bash
docker inspect -f '{{.State.Running}}' <container>
```

Without this fix, the shim rejects the `-f` flag entirely, causing container state detection to fail and tools to attempt duplicate container creation.

## Changes

- `cmd_inspect`: `-f` now treated identically to `--format`
- `cmd_inspect`: `{{.State.Running}}` format renders `true` when container state is `"running"`, `false` otherwise

## Test

```bash
docker inspect -f '{{.State.Running}}' <container>
# => true

docker inspect --format '{{.State.Running}}' <stopped-container>
# => false
```